### PR TITLE
Fixed possible memory leak in 'enqueue' func

### DIFF
--- a/src/queue.c
+++ b/src/queue.c
@@ -35,7 +35,10 @@ queue *enqueue(queue *q, void *_data) {
 
   toInsert->data = malloc(q->allocationSize);
   if (toInsert->data == NULL)
+  {
+    free(toInsert);
     return NULL;
+  }
 
   toInsert->next = NULL;
   memcpy(toInsert->data, _data, q->allocationSize);


### PR DESCRIPTION
In case, when we successfully allocate `toInsert`, but `toInsert->data` cannot be allocated - we dont simply return `NULL` in that case (leaving `toInsert` allocated), but also de-allocate it :)